### PR TITLE
Fix regex duplicate check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -660,7 +660,7 @@ function extractToolCalls(content: string): { tool: string; args: any }[] {
   while ((match = regex2.exec(content)) !== null) {
     // regex1ですでに処理したマッチはスキップ
     const fullMatch = match[0];
-    if (regex1.test(fullMatch)) continue;
+    if (new RegExp(regex1).test(fullMatch)) continue;
     
     try {
       const tool = match[1];   // ツール名（例: ls）


### PR DESCRIPTION
## Summary
- resolve duplication check regression in `extractToolCalls` by cloning the regex before testing

## Testing
- `npm run build` *(fails: cannot find module types)*