### PR TITLE
Fix missing MCP SDK and build step

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,15 +2,17 @@
 
 ## package.jsonの修正
 
-1. `bin`セクションの参照先を修正
-   - 修正前: `"./dist/bin/ollama-code.js"`
-   - 修正後: `"./bin/ollama-code.js"`
+1. `bin`セクションの参照先を再度修正
+   - 修正前: `"./bin/ollama-code.js"`
+   - 修正後: `"./dist/bin/ollama-code.js"`
 
 2. スクリプトの依存関係を明示化
    - `presetup`, `premcp-chat`などのスクリプトを追加し、必要なビルドを事前に実行するように修正
    - `build`スクリプトを`prebuild`, `build`, `postbuild`に分割して処理を明確化
+3. `prestart`スクリプトを追加し、`npm start`実行時に自動ビルド
+4. MCP SDK依存を追加: `@modelcontextprotocol/sdk@1.11.4`
 
-3. ビルドプロセスの整理
+5. ビルドプロセスの整理
    - TypeScriptのコンパイルとバイナリファイルの処理を分離
    - `build:bin`スクリプトを追加して実行権限設定のみを担当
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ git clone https://github.com/yourusername/ollama-code.git
 cd ollama-code
 npm install
 npm run build
+# MCP機能を利用するためのSDKはバージョンを固定しています
+# (package.jsonで@modelcontextprotocol/sdk@1.11.4)
 npm link
 ```
 
@@ -27,6 +29,9 @@ npm link
 ```bash
 ollama-code setup
 ```
+
+`npm start` を実行すると自動的にビルドが行われ、`dist` ディレクトリから CLI
+が起動します。
 
 ### 基本的な使い方
 

--- a/package.json
+++ b/package.json
@@ -4,22 +4,21 @@
   "description": "OllamaモデルとMCPを活用したコーディング支援CLI",
   "main": "dist/index.js",
   "bin": {
-    "ollama-code": "./bin/ollama-code.js"
+    "ollama-code": "./dist/bin/ollama-code.js"
   },
   "type": "module",
   "scripts": {
-    "prebuild": "tsc",
-    "build": "npm run build:bin",
-    "build:bin": "mkdir -p ./bin && cp ./dist/bin/ollama-code.js ./bin/ollama-code.js && chmod +x ./bin/ollama-code.js",
-    "postbuild": "",
-    "start": "node ./bin/ollama-code.js",
+    "build": "tsc",
+    "postbuild": "chmod +x ./dist/bin/ollama-code.js",
+    "prestart": "npm run build",
+    "start": "node ./dist/bin/ollama-code.js",
     "watch": "tsc --watch",
     "dev": "npm run build && npm start",
     "presetup": "npm run build",
-    "setup": "node ./bin/ollama-code.js setup",
+    "setup": "node ./dist/bin/ollama-code.js setup",
     "premcp-chat": "npm run build",
-    "mcp-chat": "node ./bin/ollama-code.js mcp-chat",
-    "clean": "rm -rf dist bin"
+    "mcp-chat": "node ./dist/bin/ollama-code.js mcp-chat",
+    "clean": "rm -rf dist"
   },
   "keywords": [
     "ollama",
@@ -39,7 +38,8 @@
     "dotenv": "^16.3.1",
     "inquirer": "^8.2.5",
     "node-fetch": "^3.3.2",
-    "ollama": "^0.5.15"
+    "ollama": "^0.5.15",
+    "@modelcontextprotocol/sdk": "1.11.4"
   },
   "devDependencies": {
     "@types/inquirer": "^8.2.5",


### PR DESCRIPTION
## Summary
- add `prestart` script so `npm start` triggers a build
- include `@modelcontextprotocol/sdk` dependency pinned to 1.11.4
- document the SDK version and auto-build behavior in README
- log the changes in CHANGES.md

## Testing
- `npm install` *(fails: EHOSTUNREACH)*
- `npm run build` *(fails: cannot find module '@modelcontextprotocol/sdk')*
- `node --test`